### PR TITLE
Pass project name in Ghidra CI actions

### DIFF
--- a/.github/workflows/export-ghidra.yml
+++ b/.github/workflows/export-ghidra.yml
@@ -62,7 +62,7 @@ jobs:
         if [[ -e config/ghidra-user-maps.toml ]]; then
           USER_MAPS_ARG="--user-mappings=config/ghidra-user-maps.toml"
         fi
-        python scripts/export_ghidra_database.py $USER_MAPS_ARG --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER" "$RE_REPO_NAME" ${{ matrix.type }}
+        python scripts/export_ghidra_database.py $USER_MAPS_ARG --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project_name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER" "$RE_REPO_NAME" ${{ matrix.type }}
         rm ssh_key
       env: # Or as an environment variable
         GHIDRA_SSH_AUTH: ${{ secrets.GHIDRA_SSH_AUTH }}

--- a/.github/workflows/export-ghidra.yml
+++ b/.github/workflows/export-ghidra.yml
@@ -62,7 +62,7 @@ jobs:
         if [[ -e config/ghidra-user-maps.toml ]]; then
           USER_MAPS_ARG="--user-mappings=config/ghidra-user-maps.toml"
         fi
-        python scripts/export_ghidra_database.py $USER_MAPS_ARG --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project_name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER" "$RE_REPO_NAME" ${{ matrix.type }}
+        python scripts/export_ghidra_database.py $USER_MAPS_ARG --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project-name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER" "$RE_REPO_NAME" ${{ matrix.type }}
         rm ssh_key
       env: # Or as an environment variable
         GHIDRA_SSH_AUTH: ${{ secrets.GHIDRA_SSH_AUTH }}

--- a/.github/workflows/update-mapping.yml
+++ b/.github/workflows/update-mapping.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Update mapping
       run: |
         echo "$GHIDRA_SSH_AUTH" > ssh_key
-        python scripts/update_mapping.py --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project_name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER"
+        python scripts/update_mapping.py --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project-name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER"
         rm ssh_key
       env: # Or as an environment variable
         GHIDRA_SSH_AUTH: ${{ secrets.GHIDRA_SSH_AUTH }}

--- a/.github/workflows/update-mapping.yml
+++ b/.github/workflows/update-mapping.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Update mapping
       run: |
         echo "$GHIDRA_SSH_AUTH" > ssh_key
-        python scripts/update_mapping.py --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER"
+        python scripts/update_mapping.py --username github-action --ssh-key ssh_key --program "$GHIDRA_FILE_NAME" --project_name "$GHIDRA_PROJECT_NAME" "ghidra://$GHIDRA_SERVER/$GHIDRA_PROJECT_NAME/$GHIDRA_FOLDER"
         rm ssh_key
       env: # Or as an environment variable
         GHIDRA_SSH_AUTH: ${{ secrets.GHIDRA_SSH_AUTH }}

--- a/scripts/update_mapping.py
+++ b/scripts/update_mapping.py
@@ -13,6 +13,7 @@ SCRIPT_PATH = Path(os.path.realpath(__file__)).parent
 def updateMapping(args, mapping_path):
     ghidra_helpers.runAnalyze(
         args.GHIDRA_REPO_NAME,
+        project_name=args.project_name,
         process=args.program,
         username=args.username,
         ssh_key=args.ssh_key,
@@ -35,6 +36,7 @@ def main():
                         To enable SSH auth, add -ssh in the wrapper.parameters of the Ghidra Server's server.conf""",
     )
     parser.add_argument("--program", help="Program to export")
+    parser.add_argument("--project-name")
     args = parser.parse_args()
 
     mapping_path = SCRIPT_PATH.parent / "config" / "mapping.csv"


### PR DESCRIPTION
Adds a `--project-name` parameter to the update mapping and Ghidra export CI actions, as required by commit 6d61423
. Currently, the update mapping action fails and this should fix that.